### PR TITLE
Identify Album also by Alternate value (i.e. INT1, HS1, Compil1, ...)

### DIFF
--- a/src/BedethequeScraper2.py
+++ b/src/BedethequeScraper2.py
@@ -880,7 +880,7 @@ def parseSerieInfo(book, serieUrl, lDirect):
 			n, a, url, title = r.group(1), r.group(2), r.group(3), r.group(4)
 			num = if_else(n,n, if_else(a, a, ""))
 			ListAlbumAll.append([url, num + ". " + title, str(i).zfill(3)])
-			if dlgNumber != "" and (n == dlgNumber) and not lDirect:
+			if dlgNumber != "" and (num == dlgNumber) and not lDirect:
 				ListAlbum.append([url, num + ". " + title, str(i).zfill(3)])
 			i = i + 1
 		


### PR DESCRIPTION
when an album was defined in ComicRack with a Volume Number like INT1,HS1,.... It was never automatically retrieved from Bedetheque website because those alternate numbers were not used in the comparison. So, full volume list was always proposed.